### PR TITLE
Use Path.DirectorySeparatorChar for portability

### DIFF
--- a/Source/Cvent.SchemaToPoco.Core/JsonSchemaToPoco.cs
+++ b/Source/Cvent.SchemaToPoco.Core/JsonSchemaToPoco.cs
@@ -9,6 +9,7 @@ using Cvent.SchemaToPoco.Types;
 using NLog;
 using NLog.Config;
 using NLog.Targets;
+using System.IO;
 
 namespace Cvent.SchemaToPoco.Core
 {
@@ -109,7 +110,7 @@ namespace Cvent.SchemaToPoco.Core
             {
                 if (!_configuration.Verbose)
                 {
-                    string saveLoc = _configuration.OutputDirectory + @"\" + entry.Key.Namespace.Replace('.', '\\') + @"\" + entry.Key.Schema.Title +
+                    string saveLoc = _configuration.OutputDirectory + Path.DirectorySeparatorChar + entry.Key.Namespace.Replace('.', Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar + entry.Key.Schema.Title +
                                      ".cs";
                     IoUtils.GenerateFile(entry.Value, saveLoc);
                     Console.WriteLine("Wrote " + saveLoc);

--- a/Source/Cvent.SchemaToPoco.Core/Util/IOUtils.cs
+++ b/Source/Cvent.SchemaToPoco.Core/Util/IOUtils.cs
@@ -16,8 +16,8 @@ namespace Cvent.SchemaToPoco.Core.Util
         /// <param name="ns">Namespace ie. com.cvent</param>
         public static void CreateDirectoryFromNamespace(string baseDir, string ns)
         {
-            string nsDir = ns.Replace('.', '\\');
-            Directory.CreateDirectory(baseDir + @"\" + nsDir);
+            string nsDir = ns.Replace('.', Path.DirectorySeparatorChar);
+            Directory.CreateDirectory(baseDir + Path.DirectorySeparatorChar + nsDir);
         }
 
         /// <summary>
@@ -73,9 +73,9 @@ namespace Cvent.SchemaToPoco.Core.Util
 
             if (!preserveSlashes)
             {
-                if (!baseUri.ToString().EndsWith(@"\"))
+                if (!baseUri.ToString().EndsWith(Path.DirectorySeparatorChar.ToString()))
                 {
-                    baseUri = new Uri(baseUri + @"\");
+                    baseUri = new Uri(baseUri.ToString() + Path.DirectorySeparatorChar);
                 }
             }
 


### PR DESCRIPTION
Replaced usages of literal backslash in paths with
Path.DirectorySeparatorChar in order to allow paths to be constructed
properly when not running on a Windows system.

Before this change when runing using Mono on a Mac, output files would
have backslashes in the file name instead of being placed in the
apropriate directory structure. After this change, files are placed
properly.